### PR TITLE
Created test helpers package for plugins. Added Context to options.

### DIFF
--- a/binder_test.go
+++ b/binder_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/robsignorelli/configify"
+	"github.com/robsignorelli/configify/configifytest"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -14,7 +15,7 @@ func TestBinderSuite(t *testing.T) {
 }
 
 type BinderSuite struct {
-	SourceSuite
+	configifytest.SourceSuite
 }
 
 type TestStruct struct {
@@ -168,7 +169,7 @@ func (suite BinderSuite) TestModelBinder_NilSource() {
 // up and a source that will never return valid values leaves the input alone.
 func (suite BinderSuite) TestModelBinder_NoDefaults() {
 	input := TestStruct{}
-	source := NewMockSource(func(source *MockSource) {})
+	source := configifytest.NewMockSource(func(source *configifytest.MockSource) {})
 	configify.NewBinder(source).Bind(&input)
 
 	suite.Equal("", input.String)
@@ -216,7 +217,7 @@ func (suite BinderSuite) TestModelBinder_NoDefaults() {
 // with no overrides leaves the input alone. It should have all the same values it came in with.
 func (suite BinderSuite) TestModelBinder_KeepDefaults() {
 	input := suite.populateTestStruct()
-	source := NewMockSource(func(source *MockSource) {})
+	source := configifytest.NewMockSource(func(source *configifytest.MockSource) {})
 	configify.NewBinder(source).Bind(&input)
 
 	suite.Equal("A", input.String)
@@ -283,7 +284,7 @@ func (suite BinderSuite) TestModelBinder_KeepDefaults() {
 // are found within the source. This will also ensure that all of the necessary
 func (suite BinderSuite) TestModelBinder_OverrideEverything() {
 	input := suite.populateTestStruct()
-	source := NewMockSource(func(source *MockSource) {
+	source := configifytest.NewMockSource(func(source *configifytest.MockSource) {
 		source.On("String", "STRING").Return("New-A", true)
 		source.On("String", "STRING2").Return("New-B", true)
 		source.On("String", "STRING_VALUE").Return("New-C", true)

--- a/configifytest/mocks.go
+++ b/configifytest/mocks.go
@@ -1,4 +1,4 @@
-package configify_test
+package configifytest
 
 import (
 	"time"

--- a/configifytest/source_suite.go
+++ b/configifytest/source_suite.go
@@ -1,0 +1,105 @@
+package configifytest
+
+import (
+	"time"
+
+	"github.com/robsignorelli/configify"
+	"github.com/stretchr/testify/suite"
+)
+
+type SourceSuite struct {
+	suite.Suite
+	Source configify.Source
+}
+
+func (suite SourceSuite) checkOK(key string, expectedOK bool, ok bool) bool {
+	if !expectedOK {
+		return suite.False(ok, "Value for '%s' should not exist", key)
+	}
+	return suite.True(ok, "Value for '%s' was not found", key)
+}
+
+func (suite SourceSuite) ExpectString(key string, expected string, expectedOK bool) bool {
+	output, ok := suite.Source.String(key)
+	return suite.checkOK(key, expectedOK, ok) && suite.Equal(expected, output)
+}
+
+func (suite SourceSuite) ExpectStringSlice(key string, expected []string, expectedOK bool) bool {
+	output, ok := suite.Source.StringSlice(key)
+	return suite.checkOK(key, expectedOK, ok) && suite.ElementsMatch(expected, output)
+}
+
+func (suite SourceSuite) ExpectInt(key string, expected int, expectedOK bool) bool {
+	output, ok := suite.Source.Int(key)
+	return suite.checkOK(key, expectedOK, ok) && suite.Equal(expected, output)
+}
+
+func (suite SourceSuite) ExpectInt8(key string, expected int8, expectedOK bool) bool {
+	output, ok := suite.Source.Int8(key)
+	return suite.checkOK(key, expectedOK, ok) && suite.Equal(expected, output)
+}
+
+func (suite SourceSuite) ExpectInt16(key string, expected int16, expectedOK bool) bool {
+	output, ok := suite.Source.Int16(key)
+	return suite.checkOK(key, expectedOK, ok) && suite.Equal(expected, output)
+}
+
+func (suite SourceSuite) ExpectInt32(key string, expected int32, expectedOK bool) bool {
+	output, ok := suite.Source.Int32(key)
+	return suite.checkOK(key, expectedOK, ok) && suite.Equal(expected, output)
+}
+
+func (suite SourceSuite) ExpectInt64(key string, expected int64, expectedOK bool) bool {
+	output, ok := suite.Source.Int64(key)
+	return suite.checkOK(key, expectedOK, ok) && suite.Equal(expected, output)
+}
+
+func (suite SourceSuite) ExpectUint(key string, expected uint, expectedOK bool) bool {
+	output, ok := suite.Source.Uint(key)
+	return suite.checkOK(key, expectedOK, ok) && suite.Equal(expected, output)
+}
+
+func (suite SourceSuite) ExpectUint8(key string, expected uint8, expectedOK bool) bool {
+	output, ok := suite.Source.Uint8(key)
+	return suite.checkOK(key, expectedOK, ok) && suite.Equal(expected, output)
+}
+
+func (suite SourceSuite) ExpectUint16(key string, expected uint16, expectedOK bool) bool {
+	output, ok := suite.Source.Uint16(key)
+	return suite.checkOK(key, expectedOK, ok) && suite.Equal(expected, output)
+}
+
+func (suite SourceSuite) ExpectUint32(key string, expected uint32, expectedOK bool) bool {
+	output, ok := suite.Source.Uint32(key)
+	return suite.checkOK(key, expectedOK, ok) && suite.Equal(expected, output)
+}
+
+func (suite SourceSuite) ExpectUint64(key string, expected uint64, expectedOK bool) bool {
+	output, ok := suite.Source.Uint64(key)
+	return suite.checkOK(key, expectedOK, ok) && suite.Equal(expected, output)
+}
+
+func (suite SourceSuite) ExpectFloat32(key string, expected float32, expectedOK bool) bool {
+	output, ok := suite.Source.Float32(key)
+	return suite.checkOK(key, expectedOK, ok) && suite.Equal(expected, output)
+}
+
+func (suite SourceSuite) ExpectFloat64(key string, expected float64, expectedOK bool) bool {
+	output, ok := suite.Source.Float64(key)
+	return suite.checkOK(key, expectedOK, ok) && suite.Equal(expected, output)
+}
+
+func (suite SourceSuite) ExpectBool(key string, expected bool, expectedOK bool) bool {
+	output, ok := suite.Source.Bool(key)
+	return suite.checkOK(key, expectedOK, ok) && suite.Equal(expected, output)
+}
+
+func (suite SourceSuite) ExpectDuration(key string, expected time.Duration, expectedOK bool) bool {
+	output, ok := suite.Source.Duration(key)
+	return suite.checkOK(key, expectedOK, ok) && suite.Equal(expected, output)
+}
+
+func (suite SourceSuite) ExpectTime(key string, expected time.Time, expectedOK bool) bool {
+	output, ok := suite.Source.Time(key)
+	return suite.checkOK(key, expectedOK, ok) && suite.Equal(expected, output)
+}

--- a/empty_test.go
+++ b/empty_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/robsignorelli/configify"
+	"github.com/robsignorelli/configify/configifytest"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -13,12 +14,12 @@ func TestDefaultSuite(t *testing.T) {
 }
 
 type DefaultSuite struct {
-	SourceSuite
+	configifytest.SourceSuite
 }
 
 func (suite DefaultSuite) TestAll() {
-	suite.source = configify.Empty()
-	options := suite.source.Options()
+	suite.Source = configify.Empty()
+	options := suite.Source.Options()
 	suite.Equal("", options.Namespace.Name)
 	suite.Equal("", options.Namespace.Delimiter)
 	suite.Nil(options.Defaults)

--- a/environment_test.go
+++ b/environment_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/robsignorelli/configify"
+	"github.com/robsignorelli/configify/configifytest"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -15,7 +16,7 @@ func TestEnvironmentSuite(t *testing.T) {
 }
 
 type EnvironmentSuite struct {
-	SourceSuite
+	configifytest.SourceSuite
 }
 
 func (suite *EnvironmentSuite) SetupSuite() {
@@ -55,7 +56,7 @@ func (suite *EnvironmentSuite) SetupSuite() {
 	suite.set("FOO_STRING", "foo")
 	suite.set("FOO_INT", "5")
 
-	suite.source, _ = configify.Environment(configify.Options{
+	suite.Source, _ = configify.Environment(configify.Options{
 		Namespace: configify.Namespace{Name: "TEST"},
 	})
 }
@@ -331,7 +332,7 @@ func (suite EnvironmentSuite) TestTime() {
 }
 
 func (suite EnvironmentSuite) TestDefaults() {
-	def := NewMockSource(func(s *MockSource) {
+	def := configifytest.NewMockSource(func(s *configifytest.MockSource) {
 		s.On("String", "STRING_MOCK").Return("asdf", true)
 		s.On("StringSlice", "STRING_SLICE_MOCK").Return([]string{"a", "b"}, true)
 		s.On("Int", "INT_MOCK").Return(8, true)
@@ -339,7 +340,7 @@ func (suite EnvironmentSuite) TestDefaults() {
 	})
 
 	var err error
-	suite.source, err = configify.Environment(configify.Options{
+	suite.Source, err = configify.Environment(configify.Options{
 		Namespace: configify.Namespace{Name: "TEST"},
 		Defaults:  def,
 	})

--- a/map_test.go
+++ b/map_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/robsignorelli/configify"
+	"github.com/robsignorelli/configify/configifytest"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -14,11 +15,11 @@ func TestMapSuite(t *testing.T) {
 }
 
 type MapSuite struct {
-	SourceSuite
+	configifytest.SourceSuite
 }
 
 func (suite *MapSuite) SetupSuite() {
-	suite.source = configify.Map(configify.Values{
+	suite.Source = configify.Map(configify.Values{
 		"EMPTY":              "",
 		"STRING":             "foo",
 		"STRING_SPACE":       "  foo bar ",

--- a/source.go
+++ b/source.go
@@ -1,6 +1,7 @@
 package configify
 
 import (
+	"context"
 	"strings"
 	"time"
 )
@@ -53,6 +54,11 @@ type Options struct {
 	// environments shared with other processes/services/components that might have their own
 	// similarly named variables.
 	Namespace Namespace
+
+	// Context is utilized by only certain Source implementations that need to manage connections
+	// or timeouts. You can send a Done signal to the context to tell the source that it should
+	// close its connections and/or stop reading data from the underlying data source.
+	Context context.Context
 
 	// Defaults is an optional "fallback" for values when the source you're creating does not
 	// contain the requested value. For instance if your source has values for "FOO" and "BAR"

--- a/source_test.go
+++ b/source_test.go
@@ -1,18 +1,21 @@
 package configify_test
 
 import (
-	"time"
+	"testing"
 
 	"github.com/robsignorelli/configify"
 	"github.com/stretchr/testify/suite"
 )
 
-type SourceSuite struct {
-	suite.Suite
-	source configify.Source
+func TestNamespaceSuite(t *testing.T) {
+	suite.Run(t, new(NamespaceSuite))
 }
 
-func (suite SourceSuite) TestNamespace_Qualify() {
+type NamespaceSuite struct {
+	suite.Suite
+}
+
+func (suite NamespaceSuite) TestNamespace_Qualify() {
 	ns := configify.Namespace{}
 	suite.Equal("BAR", ns.Qualify("BAR"))
 
@@ -24,96 +27,4 @@ func (suite SourceSuite) TestNamespace_Qualify() {
 
 	ns = configify.Namespace{Name: "FOO  ", Delimiter: "  .  "}
 	suite.Equal("FOO.BAR", ns.Qualify("BAR"))
-}
-
-func (suite SourceSuite) checkOK(key string, expectedOK bool, ok bool) bool {
-	if !expectedOK {
-		return suite.False(ok, "Value for '%s' should not exist", key)
-	}
-	return suite.True(ok, "Value for '%s' was not found", key)
-}
-
-func (suite SourceSuite) ExpectString(key string, expected string, expectedOK bool) bool {
-	output, ok := suite.source.String(key)
-	return suite.checkOK(key, expectedOK, ok) && suite.Equal(expected, output)
-}
-
-func (suite SourceSuite) ExpectStringSlice(key string, expected []string, expectedOK bool) bool {
-	output, ok := suite.source.StringSlice(key)
-	return suite.checkOK(key, expectedOK, ok) && suite.ElementsMatch(expected, output)
-}
-
-func (suite SourceSuite) ExpectInt(key string, expected int, expectedOK bool) bool {
-	output, ok := suite.source.Int(key)
-	return suite.checkOK(key, expectedOK, ok) && suite.Equal(expected, output)
-}
-
-func (suite SourceSuite) ExpectInt8(key string, expected int8, expectedOK bool) bool {
-	output, ok := suite.source.Int8(key)
-	return suite.checkOK(key, expectedOK, ok) && suite.Equal(expected, output)
-}
-
-func (suite SourceSuite) ExpectInt16(key string, expected int16, expectedOK bool) bool {
-	output, ok := suite.source.Int16(key)
-	return suite.checkOK(key, expectedOK, ok) && suite.Equal(expected, output)
-}
-
-func (suite SourceSuite) ExpectInt32(key string, expected int32, expectedOK bool) bool {
-	output, ok := suite.source.Int32(key)
-	return suite.checkOK(key, expectedOK, ok) && suite.Equal(expected, output)
-}
-
-func (suite SourceSuite) ExpectInt64(key string, expected int64, expectedOK bool) bool {
-	output, ok := suite.source.Int64(key)
-	return suite.checkOK(key, expectedOK, ok) && suite.Equal(expected, output)
-}
-
-func (suite SourceSuite) ExpectUint(key string, expected uint, expectedOK bool) bool {
-	output, ok := suite.source.Uint(key)
-	return suite.checkOK(key, expectedOK, ok) && suite.Equal(expected, output)
-}
-
-func (suite SourceSuite) ExpectUint8(key string, expected uint8, expectedOK bool) bool {
-	output, ok := suite.source.Uint8(key)
-	return suite.checkOK(key, expectedOK, ok) && suite.Equal(expected, output)
-}
-
-func (suite SourceSuite) ExpectUint16(key string, expected uint16, expectedOK bool) bool {
-	output, ok := suite.source.Uint16(key)
-	return suite.checkOK(key, expectedOK, ok) && suite.Equal(expected, output)
-}
-
-func (suite SourceSuite) ExpectUint32(key string, expected uint32, expectedOK bool) bool {
-	output, ok := suite.source.Uint32(key)
-	return suite.checkOK(key, expectedOK, ok) && suite.Equal(expected, output)
-}
-
-func (suite SourceSuite) ExpectUint64(key string, expected uint64, expectedOK bool) bool {
-	output, ok := suite.source.Uint64(key)
-	return suite.checkOK(key, expectedOK, ok) && suite.Equal(expected, output)
-}
-
-func (suite SourceSuite) ExpectFloat32(key string, expected float32, expectedOK bool) bool {
-	output, ok := suite.source.Float32(key)
-	return suite.checkOK(key, expectedOK, ok) && suite.Equal(expected, output)
-}
-
-func (suite SourceSuite) ExpectFloat64(key string, expected float64, expectedOK bool) bool {
-	output, ok := suite.source.Float64(key)
-	return suite.checkOK(key, expectedOK, ok) && suite.Equal(expected, output)
-}
-
-func (suite SourceSuite) ExpectBool(key string, expected bool, expectedOK bool) bool {
-	output, ok := suite.source.Bool(key)
-	return suite.checkOK(key, expectedOK, ok) && suite.Equal(expected, output)
-}
-
-func (suite SourceSuite) ExpectDuration(key string, expected time.Duration, expectedOK bool) bool {
-	output, ok := suite.source.Duration(key)
-	return suite.checkOK(key, expectedOK, ok) && suite.Equal(expected, output)
-}
-
-func (suite SourceSuite) ExpectTime(key string, expected time.Time, expectedOK bool) bool {
-	output, ok := suite.source.Time(key)
-	return suite.checkOK(key, expectedOK, ok) && suite.Equal(expected, output)
 }


### PR DESCRIPTION
While building out the consul plugin, it's easier to standardize the test suites by extracting the mock source and suite helpers into a `configifytest` sub-package. I also added an optional `context.Context` to source options so callers have control to externally shut down the listeners for sources they create.