### PR TITLE
Convert factories to use functional options.

### DIFF
--- a/environment.go
+++ b/environment.go
@@ -9,11 +9,11 @@ import (
 // Environment creates a new config source that pull environment variables to provide configuration
 // values. This source will also try to best-guess parse things like numbers since they're all
 // natively strings.
-func Environment(options Options) (Source, error) {
-	if options.Defaults == nil {
-		options.Defaults = emptySource{}
-	}
-	return &environmentSource{options: options, massage: Massage{}}, nil
+func Environment(opts ...Option) (Source, error) {
+	options := apply(opts, &Options{
+		Defaults: emptySource{},
+	})
+	return &environmentSource{options: *options, massage: Massage{}}, nil
 }
 
 type environmentSource struct {

--- a/environment_test.go
+++ b/environment_test.go
@@ -55,7 +55,7 @@ func (suite *EnvironmentSuite) SetupSuite() {
 	suite.set("FOO_STRING", "foo")
 	suite.set("FOO_INT", "5")
 
-	suite.source, _ = configify.Environment(configify.WithNamespace("TEST", "_"))
+	suite.source, _ = configify.Environment(configify.Namespace("TEST"))
 }
 
 func (suite EnvironmentSuite) set(key string, value string) {
@@ -66,15 +66,22 @@ func (suite EnvironmentSuite) TestFactory() {
 	_, err := configify.Environment()
 	suite.NoError(err)
 
-	_, err = configify.Environment(configify.WithNamespace("", ""))
+	_, err = configify.Environment(
+		configify.Namespace(""),
+		configify.NamespaceDelim(""))
 	suite.NoError(err)
 
-	_, err = configify.Environment(configify.WithNamespace("FOO", "."))
+	_, err = configify.Environment(
+		configify.Namespace("FOO"),
+		configify.NamespaceDelim("."))
 	suite.NoError(err)
 }
 
 func (suite EnvironmentSuite) TestOptions() {
-	source, _ := configify.Environment(configify.WithNamespace("FOO", "."))
+	source, _ := configify.Environment(
+		configify.Namespace("FOO"),
+		configify.NamespaceDelim("."))
+
 	suite.Equal("FOO", source.Options().Namespace.Name)
 	suite.Equal(".", source.Options().Namespace.Delimiter)
 }
@@ -322,7 +329,7 @@ func (suite EnvironmentSuite) TestTime() {
 func (suite EnvironmentSuite) TestDefaults() {
 	var err error
 	suite.source, err = configify.Environment(
-		configify.WithNamespace("TEST", "_"),
+		configify.Namespace("TEST"),
 		configify.Defaults(configify.Values{
 			"STRING_MOCK":       "asdf",
 			"STRING_SLICE_MOCK": []string{"a", "b"},
@@ -359,7 +366,7 @@ func ExampleEnvironment() {
 
 	// Use the namespace "HELLO" because it's the common prefix for all
 	// of our environment variables. By default, we'll use "_" as the delimiter.
-	config, err := configify.Environment(configify.WithNamespace("HELLO", "_"))
+	config, err := configify.Environment(configify.Namespace("HELLO"))
 	if err != nil {
 		panic("Aww nuts...")
 	}
@@ -394,7 +401,7 @@ func ExampleEnvironmentDefaults() {
 
 	// Use that fixed map source as the defaults for the environment source.
 	config, err := configify.Environment(
-		configify.WithNamespace("HELLO", "_"),
+		configify.Namespace("HELLO"),
 		configify.Defaults(configify.Values{
 			"PORT": 9999,
 			"FOO":  "foo value",

--- a/environment_test.go
+++ b/environment_test.go
@@ -56,7 +56,7 @@ func (suite *EnvironmentSuite) SetupSuite() {
 	suite.set("FOO_STRING", "foo")
 	suite.set("FOO_INT", "5")
 
-	suite.source, _ = configify.Environment(configify.Namespace("TEST"))
+	suite.Source, _ = configify.Environment(configify.Namespace("TEST"))
 }
 
 func (suite EnvironmentSuite) set(key string, value string) {
@@ -329,7 +329,7 @@ func (suite EnvironmentSuite) TestTime() {
 
 func (suite EnvironmentSuite) TestDefaults() {
 	var err error
-	suite.source, err = configify.Environment(
+	suite.Source, err = configify.Environment(
 		configify.Namespace("TEST"),
 		configify.Defaults(configify.Values{
 			"STRING_MOCK":       "asdf",

--- a/source.go
+++ b/source.go
@@ -51,10 +51,17 @@ func Defaults(values Values) Option {
 	}
 }
 
-// WithNamespace defines a prefix to apply to all value lookups.
-func WithNamespace(name, delimiter string) Option {
+// Namespace defines a prefix to apply to all value lookups.
+func Namespace(name string) Option {
 	return func(options *Options) {
-		options.Namespace = Namespace{Name: name, Delimiter: delimiter}
+		options.Namespace.Name = name
+	}
+}
+
+// NamespaceDelim defines the separator used when joining namespaces and their keys. Defaults to "_".
+func NamespaceDelim(delimiter string) Option {
+	return func(options *Options) {
+		options.Namespace.Delimiter = delimiter
 	}
 }
 
@@ -76,7 +83,7 @@ type Options struct {
 	// This helps you enforce good variable naming practices especially when running in
 	// environments shared with other processes/services/components that might have their own
 	// similarly named variables.
-	Namespace Namespace
+	Namespace namespace
 
 	// Defaults is an optional "fallback" for values when the source you're creating does not
 	// contain the requested value. For instance if your source has values for "FOO" and "BAR"
@@ -86,18 +93,18 @@ type Options struct {
 	Defaults Source
 }
 
-// Namespace defines a fixed prefix for keys in your config store. This helps you isolate your
+// namespace defines a fixed prefix for keys in your config store. This helps you isolate your
 // config values to certain services or components. For instance for all HTTP router configuration
 // you can use the namespace "HTTP" or for the configs for your RabbitMQ component, you can use
 // the namespace "RABBITMQ", and so on.
-type Namespace struct {
+type namespace struct {
 	Name      string
 	Delimiter string
 }
 
 // Qualify takes the raw, unqualified key name (e.g. "PORT") and returns the namespace-qualified
 // key name (e.g. "HTTP_PORT").
-func (ns Namespace) Qualify(key string) string {
+func (ns namespace) Qualify(key string) string {
 	if ns.Name == "" {
 		return key
 	}
@@ -107,7 +114,7 @@ func (ns Namespace) Qualify(key string) string {
 // Join constructs a well-formed value by joining the given segments, ignoring any empty "". This
 // will ensure that there are no consecutive delimiters or leading/trailing ones. This does NOT
 // force the namespace name as a prefix!
-func (ns Namespace) Join(segments ...string) string {
+func (ns namespace) Join(segments ...string) string {
 	delim := strings.TrimSpace(ns.Delimiter)
 	if delim == "" {
 		delim = "_"

--- a/source.go
+++ b/source.go
@@ -41,6 +41,30 @@ type SourceWatcher interface {
 	Watch(callback func(source Source))
 }
 
+// Option defines a functional option setting you can utilize when configuring a new source.
+type Option func(*Options)
+
+// Defaults applies the following fallback values to the source you're creating.
+func Defaults(values Values) Option {
+	return func(options *Options) {
+		options.Defaults = Map(values)
+	}
+}
+
+// WithNamespace defines a prefix to apply to all value lookups.
+func WithNamespace(name, delimiter string) Option {
+	return func(options *Options) {
+		options.Namespace = Namespace{Name: name, Delimiter: delimiter}
+	}
+}
+
+func apply(options []Option, defaults *Options) *Options {
+	for _, option := range options {
+		option(defaults)
+	}
+	return defaults
+}
+
 // Options encapsulate the standard attributes that are shared by all sources in configify.
 type Options struct {
 	// Namespace is an optional prefix for all of your config values. This is useful for cases

--- a/source_test.go
+++ b/source_test.go
@@ -13,17 +13,22 @@ type SourceSuite struct {
 }
 
 func (suite SourceSuite) TestNamespace_Qualify() {
-	ns := configify.Namespace{}
-	suite.Equal("BAR", ns.Qualify("BAR"))
+	options := configify.Options{}
+	suite.Equal("BAR", options.Namespace.Qualify("BAR"))
 
-	ns = configify.Namespace{Name: "FOO"}
-	suite.Equal("FOO_BAR", ns.Qualify("BAR"))
+	options = configify.Options{}
+	configify.Namespace("FOO")(&options)
+	suite.Equal("FOO_BAR", options.Namespace.Qualify("BAR"))
 
-	ns = configify.Namespace{Name: "FOO", Delimiter: "."}
-	suite.Equal("FOO.BAR", ns.Qualify("BAR"))
+	options = configify.Options{}
+	configify.Namespace("FOO")(&options)
+	configify.NamespaceDelim(".")(&options)
+	suite.Equal("FOO.BAR", options.Namespace.Qualify("BAR"))
 
-	ns = configify.Namespace{Name: "FOO  ", Delimiter: "  .  "}
-	suite.Equal("FOO.BAR", ns.Qualify("BAR"))
+	options = configify.Options{}
+	configify.Namespace("FOO")(&options)
+	configify.NamespaceDelim("  .  ")(&options)
+	suite.Equal("FOO.BAR", options.Namespace.Qualify("BAR"))
 }
 
 func (suite SourceSuite) checkOK(key string, expectedOK bool, ok bool) bool {

--- a/source_test.go
+++ b/source_test.go
@@ -15,7 +15,7 @@ type NamespaceSuite struct {
 	suite.Suite
 }
 
-func (suite SourceSuite) TestNamespace_Qualify() {
+func (suite NamespaceSuite) TestNamespace_Qualify() {
 	options := configify.Options{}
 	suite.Equal("BAR", options.Namespace.Qualify("BAR"))
 


### PR DESCRIPTION
The options struct was too verbose and made it hard to determine what was required (nothing) and what was optional.