### PR TITLE
Fix/sized ints

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ func main() {
 	// The 'ok' return value indicates whether we found that value in the
 	// source or not. For instance, is "DEBUG_MODE" false because it wasn't
 	// in the environment or did you explicitly set it to "false"?
-	env, ok := configify.Environment()
+	env := configify.Environment()
 	host, ok := env.String("HTTP_HOST")
 	port, ok := env.Uint("HTTP_PORT")
 	debugMode, ok := env.Bool("DEBUG_MODE")

--- a/binder.go
+++ b/binder.go
@@ -43,7 +43,7 @@ func (b standardBinder) bindPrefix(out interface{}, prefix string) {
 	b.bindPrefixWithType(out, prefix, outType, outValue)
 }
 
-func (b standardBinder) bindPrefixWithType(out interface{}, prefix string, outType reflect.Type, outValue reflect.Value) {
+func (b standardBinder) bindPrefixWithType(_ interface{}, prefix string, outType reflect.Type, outValue reflect.Value) {
 	for i := 0; i < outType.NumField(); i++ {
 		field := outType.Field(i)
 		value := outValue.Field(i)
@@ -81,9 +81,45 @@ func (b standardBinder) updateValue(field reflect.StructField, value reflect.Val
 		if v, ok := b.Source.Int(key); ok {
 			value.SetInt(int64(v))
 		}
+	case reflect.Int8:
+		if v, ok := b.Source.Int8(key); ok {
+			value.SetInt(int64(v))
+		}
+	case reflect.Int16:
+		if v, ok := b.Source.Int16(key); ok {
+			value.SetInt(int64(v))
+		}
+	case reflect.Int32:
+		if v, ok := b.Source.Int32(key); ok {
+			value.SetInt(int64(v))
+		}
+	case reflect.Int64:
+		if v, ok := b.Source.Int64(key); ok {
+			value.SetInt(v)
+		}
 	case reflect.Uint:
 		if v, ok := b.Source.Uint(key); ok {
 			value.SetUint(uint64(v))
+		}
+	case reflect.Uint8:
+		if v, ok := b.Source.Uint8(key); ok {
+			value.SetUint(uint64(v))
+		}
+	case reflect.Uint16:
+		if v, ok := b.Source.Uint16(key); ok {
+			value.SetUint(uint64(v))
+		}
+	case reflect.Uint32:
+		if v, ok := b.Source.Uint32(key); ok {
+			value.SetUint(uint64(v))
+		}
+	case reflect.Uint64:
+		if v, ok := b.Source.Uint64(key); ok {
+			value.SetUint(v)
+		}
+	case reflect.Float32:
+		if v, ok := b.Source.Float32(key); ok {
+			value.SetFloat(float64(v))
 		}
 	case reflect.Float64:
 		if v, ok := b.Source.Float64(key); ok {

--- a/binder_test.go
+++ b/binder_test.go
@@ -35,11 +35,21 @@ type TestStruct struct {
 	IntRenamed int `conf:"some_int"`
 	IntPointer *int
 
+	Int8  int8
+	Int16 int16
+	Int32 int32
+	Int64 int64
+
 	Uint        uint
 	Uint2       uint
 	UintValue   uint
 	UintRenamed uint `conf:"some_uint"`
 	UintPointer *uint
+
+	Uint8  uint8
+	Uint16 uint16
+	Uint32 uint32
+	Uint64 uint64
 
 	Bool        bool
 	BoolPointer *bool
@@ -102,6 +112,16 @@ func (suite BinderSuite) populateTestStruct() TestStruct {
 		UintValue:   uint(13),
 		UintRenamed: uint(14),
 		UintPointer: &uintPointerVal,
+
+		Uint8:  72,
+		Uint16: 1072,
+		Uint32: 1000072,
+		Uint64: 1000000072,
+
+		Int8:  72,
+		Int16: 1072,
+		Int32: 1000072,
+		Int64: 1000000072,
 
 		StringSlice:        []string{"Foo1", "Bar1"},
 		StringSlice2:       []string{"Foo2", "Bar2"},
@@ -190,6 +210,16 @@ func (suite BinderSuite) TestModelBinder_NoDefaults() {
 	suite.Equal(uint(0), input.UintRenamed)
 	suite.Nil(input.UintPointer)
 
+	suite.Equal(int8(0), input.Int8)
+	suite.Equal(int16(0), input.Int16)
+	suite.Equal(int32(0), input.Int32)
+	suite.Equal(int64(0), input.Int64)
+
+	suite.Equal(int8(0), input.Int8)
+	suite.Equal(int16(0), input.Int16)
+	suite.Equal(int32(0), input.Int32)
+	suite.Equal(int64(0), input.Int64)
+
 	suite.Nil(input.StringSlice)
 	suite.Nil(input.StringSlice2)
 	suite.Nil(input.StringSliceRenamed)
@@ -237,6 +267,16 @@ func (suite BinderSuite) TestModelBinder_KeepDefaults() {
 	suite.Equal(uint(13), input.UintValue)
 	suite.Equal(uint(14), input.UintRenamed)
 	suite.Equal(uint(15), *input.UintPointer)
+
+	suite.Equal(uint8(72), input.Uint8)
+	suite.Equal(uint16(1072), input.Uint16)
+	suite.Equal(uint32(1000072), input.Uint32)
+	suite.Equal(uint64(1000000072), input.Uint64)
+
+	suite.Equal(int8(72), input.Int8)
+	suite.Equal(int16(1072), input.Int16)
+	suite.Equal(int32(1000072), input.Int32)
+	suite.Equal(int64(1000000072), input.Int64)
 
 	suite.ElementsMatch([]string{"Foo1", "Bar1"}, input.StringSlice)
 	suite.ElementsMatch([]string{"Foo2", "Bar2"}, input.StringSlice2)
@@ -308,6 +348,16 @@ func (suite BinderSuite) TestModelBinder_OverrideEverything() {
 		source.On("Uint", "some_uint").Return(uint(114), true)
 		source.On("Uint", "UINT_POINTER").Return(uint(115), true)
 
+		source.On("Uint8", "UINT8").Return(uint8(120), true)
+		source.On("Uint16", "UINT16").Return(uint16(121), true)
+		source.On("Uint32", "UINT32").Return(uint32(122), true)
+		source.On("Uint64", "UINT64").Return(uint64(123), true)
+
+		source.On("Int8", "INT8").Return(int8(124), true)
+		source.On("Int16", "INT16").Return(int16(125), true)
+		source.On("Int32", "INT32").Return(int32(126), true)
+		source.On("Int64", "INT64").Return(int64(127), true)
+
 		// They defaults on the struct are true, so flip them back to false.
 		source.On("Bool", "BOOL").Return(false, true)
 		source.On("Bool", "BOOL_POINTER").Return(false, true)
@@ -370,6 +420,16 @@ func (suite BinderSuite) TestModelBinder_OverrideEverything() {
 	suite.Equal(uint(113), input.UintValue)
 	suite.Equal(uint(114), input.UintRenamed)
 	suite.Equal(uint(115), *input.UintPointer)
+
+	suite.Equal(uint8(120), input.Uint8)
+	suite.Equal(uint16(121), input.Uint16)
+	suite.Equal(uint32(122), input.Uint32)
+	suite.Equal(uint64(123), input.Uint64)
+
+	suite.Equal(int8(124), input.Int8)
+	suite.Equal(int16(125), input.Int16)
+	suite.Equal(int32(126), input.Int32)
+	suite.Equal(int64(127), input.Int64)
 
 	suite.Equal(false, input.Bool)
 	suite.Equal(false, *input.BoolPointer)

--- a/environment.go
+++ b/environment.go
@@ -9,11 +9,11 @@ import (
 // Environment creates a new config source that pull environment variables to provide configuration
 // values. This source will also try to best-guess parse things like numbers since they're all
 // natively strings.
-func Environment(opts ...Option) (Source, error) {
+func Environment(opts ...Option) Source {
 	options := apply(opts, &Options{
 		Defaults: emptySource{},
 	})
-	return &environmentSource{options: *options, massage: Massage{}}, nil
+	return &environmentSource{options: *options, massage: Massage{}}
 }
 
 type environmentSource struct {

--- a/environment_test.go
+++ b/environment_test.go
@@ -56,30 +56,15 @@ func (suite *EnvironmentSuite) SetupSuite() {
 	suite.set("FOO_STRING", "foo")
 	suite.set("FOO_INT", "5")
 
-	suite.Source, _ = configify.Environment(configify.Namespace("TEST"))
+	suite.Source = configify.Environment(configify.Namespace("TEST"))
 }
 
 func (suite EnvironmentSuite) set(key string, value string) {
 	_ = os.Setenv(key, value)
 }
 
-func (suite EnvironmentSuite) TestFactory() {
-	_, err := configify.Environment()
-	suite.NoError(err)
-
-	_, err = configify.Environment(
-		configify.Namespace(""),
-		configify.NamespaceDelim(""))
-	suite.NoError(err)
-
-	_, err = configify.Environment(
-		configify.Namespace("FOO"),
-		configify.NamespaceDelim("."))
-	suite.NoError(err)
-}
-
 func (suite EnvironmentSuite) TestOptions() {
-	source, _ := configify.Environment(
+	source := configify.Environment(
 		configify.Namespace("FOO"),
 		configify.NamespaceDelim("."))
 
@@ -328,8 +313,7 @@ func (suite EnvironmentSuite) TestTime() {
 }
 
 func (suite EnvironmentSuite) TestDefaults() {
-	var err error
-	suite.Source, err = configify.Environment(
+	suite.Source = configify.Environment(
 		configify.Namespace("TEST"),
 		configify.Defaults(configify.Values{
 			"STRING_MOCK":       "asdf",
@@ -337,7 +321,6 @@ func (suite EnvironmentSuite) TestDefaults() {
 			"INT_MOCK":          8,
 			"UINT_MOCK":         uint(9),
 		}))
-	suite.Require().NoError(err)
 
 	// For each, make sure that (A) a valid env value resolves, (B) a value in the fixed fallback
 	// resolves, and (C) a value that doesn't exist in either uses the hard-coded defaults.
@@ -367,13 +350,10 @@ func ExampleEnvironment() {
 
 	// Use the namespace "HELLO" because it's the common prefix for all
 	// of our environment variables. By default, we'll use "_" as the delimiter.
-	config, err := configify.Environment(configify.Namespace("HELLO"))
-	if err != nil {
-		panic("Aww nuts...")
-	}
+	config := configify.Environment(configify.Namespace("HELLO"))
 
 	// Each value fetch gives you the parsed value as well as an 'ok'
-	// as to whether the value actually existed in the source or not.
+	// whether the value actually existed in the source or not.
 	host, ok := config.String("HOST")
 	fmt.Printf("Host:    [%s] (%v)\n", host, ok)
 
@@ -401,16 +381,13 @@ func ExampleEnvironmentDefaults() {
 	_ = os.Setenv("HELLO_TIMEOUT", "20s")
 
 	// Use that fixed map source as the defaults for the environment source.
-	config, err := configify.Environment(
+	config := configify.Environment(
 		configify.Namespace("HELLO"),
 		configify.Defaults(configify.Values{
 			"PORT": 9999,
 			"FOO":  "foo value",
 			"BAR":  "bar value",
 		}))
-	if err != nil {
-		panic("Aww nuts...")
-	}
 
 	host, ok := config.String("HOST")
 	fmt.Printf("Host:    [%s] (%v)\n", host, ok)


### PR DESCRIPTION
The binding code handled `int` and `uint` but not any of the sized variants like `uint8`, `int64`, and such. Now it works.